### PR TITLE
Reverts to Lock

### DIFF
--- a/Observable/Classes/Lock.swift
+++ b/Observable/Classes/Lock.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// https://cocoawithlove.com/blog/2016/06/02/threads-and-mutexes.html
+// http://www.vadimbulavin.com/atomic-properties/
+// https://stackoverflow.com/a/47345863/976628
+internal protocol Lock {
+    func lock()
+    func unlock()
+}
+
+internal final class Mutex: Lock {
+    private var mutex: pthread_mutex_t = {
+        var mutex = pthread_mutex_t()
+        pthread_mutex_init(&mutex, nil)
+        return mutex
+    }()
+
+    func lock() {
+        pthread_mutex_lock(&mutex)
+    }
+
+    func unlock() {
+        pthread_mutex_unlock(&mutex)
+    }
+}

--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -1,42 +1,40 @@
 import Foundation
 
 public class ImmutableObservable<T> {
-
+    
     public typealias Observer = (T, T?) -> Void
-
+    
     private var observers: [Int: (Observer, DispatchQueue?)] = [:]
     private var uniqueID = (0...).makeIterator()
-
-    fileprivate let readWriteQueue: DispatchQueue = DispatchQueue(label: "Observable.ReadWriteQueue")
-    fileprivate let observersQueue: DispatchQueue = DispatchQueue(label: "Observable.ObserversQueue")
-
+    
+    fileprivate let lock: Lock = Mutex()
+    
     fileprivate var _value: T {
         didSet {
-            observersQueue.async {
-                self.observers.values.forEach { observer, dispatchQueue in
-                    if let dispatchQueue = dispatchQueue {
-                        dispatchQueue.async {
-                            observer(self.value, oldValue)
-                        }
-                    } else {
+            observers.values.forEach { observer, dispatchQueue in
+                if let dispatchQueue = dispatchQueue {
+                    dispatchQueue.async {
                         observer(self.value, oldValue)
                     }
+                } else {
+                    observer(value, oldValue)
                 }
             }
         }
     }
-
+    
     public var value: T {
-        return readWriteQueue.sync {
-            return _value
-        }
+        return _value
     }
-
+    
     public init(_ value: T) {
         self._value = value
     }
-
+    
     public func observe(_ queue: DispatchQueue? = nil, _ observer: @escaping Observer) -> Disposable {
+        lock.lock()
+        defer { lock.unlock() }
+        
         let id = uniqueID.next()!
         
         observers[id] = (observer, queue)
@@ -48,24 +46,22 @@ public class ImmutableObservable<T> {
         
         return disposable
     }
-
+    
     public func removeAllObservers() {
         observers.removeAll()
     }
 }
 
 public class Observable<T>: ImmutableObservable<T> {
-
+    
     public override var value: T {
         get {
-            return readWriteQueue.sync {
-                return _value
-            }
+            return _value
         }
         set {
-            readWriteQueue.async {
-                self._value = newValue
-            }
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
         }
     }
 }


### PR DESCRIPTION
According to discussion in #20, removes DispatchQueue and reverts to using Mutex. Deadlock should be avoided by the user specifying a DispatchQueue.