### PR TITLE
Add helper method to create an ImmutableObservable

### DIFF
--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -54,6 +54,10 @@ public class ImmutableObservable<T> {
     public func removeAllObservers() {
         observers.removeAll()
     }
+    
+    public func asImmutable() -> ImmutableObservable<T> {
+        return self
+    }
 }
 
 public class Observable<T>: ImmutableObservable<T> {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ class SomeViewModel {
     var position: ImmutableObservable<CGPoint> = {
         return positionSubject
     }
+    // Or use the helper method Observable.asImmutable()
+    // lazy var position = positionSubject.asImmutable()
 
     /// Private property, that can be changed / observed inside this view model.
     private let positionSubject = Observable(CGPoint.zero)


### PR DESCRIPTION
Sometimes it's error prone when changing a type of Observable and ImmutableObservable, because we need to change the type in two places.

This is why I created this helper method to create an ImmutableObservable

`lazy var position = positionSubject.asImmutable()`
