### PR TITLE
Fix change value multiple times on the same DispatchQueue as observed

### DIFF
--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -11,13 +11,14 @@ public class ImmutableObservable<T> {
     
     fileprivate var _value: T {
         didSet {
+            let newValue = _value
             observers.values.forEach { observer, dispatchQueue in
                 if let dispatchQueue = dispatchQueue {
                     dispatchQueue.async {
-                        observer(self.value, oldValue)
+                        observer(newValue, oldValue)
                     }
                 } else {
-                    observer(value, oldValue)
+                    observer(newValue, oldValue)
                 }
             }
         }


### PR DESCRIPTION
I found an issue when observing changes and emitting multiple changes booth in the main thread.
Consider the following code:
```
    private var disposal = Disposal()
    
    var observable = Observable(0)
    
    func test() {
        // run on the main thread
        observable.observe(DispatchQueue.main) { newValue, oldValue in
            print("newValue = \(newValue) || oldValue = \(oldValue)")
            }.add(to: &disposal)
        
        observable.value = 1
        observable.value = 2
        observable.value = 3
        observable.value = 4
        
    }
```

Without this fix, the output is
```
//newValue = 0 || oldValue = nil
//newValue = 4 || oldValue = Optional(0)
//newValue = 4 || oldValue = Optional(1)
//newValue = 4 || oldValue = Optional(2)
//newValue = 4 || oldValue = Optional(3)
```

With this fix, the output is
```
//newValue = 0 || oldValue = nil
//newValue = 1 || oldValue = Optional(0)
//newValue = 2 || oldValue = Optional(1)
//newValue = 3 || oldValue = Optional(2)
//newValue = 4 || oldValue = Optional(3)
```
