### PR TITLE
Update readme - Migrate Observable and MutableObservable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ let observable = Observable([URL]()) {
 }
 ```
 
-### Model Properties as @Observable
+### Model Properties as @MutableObservable
 
 Now mark your binded/mapped properties as observable and export public observable
 
 ```swift
 //Private Observer
-@Observable var text: String = "Test"
+@MutableObservable var text: String = "Test"
 
 //add observer
 


### PR DESCRIPTION
In https://github.com/roberthein/Observable/pull/33 `Observable` was renamed to `MutableObservable`, but I forgot to update the readme.