### PR TITLE
Temporarily revert open classes

### DIFF
--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class Observable<T> {
+public class Observable<T> {
     
     public typealias Observer = (T, T?) -> Void
     
@@ -72,7 +72,7 @@ open class Observable<T> {
 }
 
 @propertyWrapper
-open class MutableObservable<T>: Observable<T> {
+public class MutableObservable<T>: Observable<T> {
     
     override public var wrappedValue: T {
         get {

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ let observable = Observable([URL]()) {
 }
 ```
 
-### Model Properties as @Observable
+### Model Properties as @MutableObservable
 
 Now mark your binded/mapped properties as observable and export public observable
 
 ```swift
 //Private Observer
-@Observable var text: String = "Test"
+@MutableObservable var text: String = "Test"
 
 //add observer
 


### PR DESCRIPTION
In https://github.com/roberthein/Observable/pull/34 some classes were open for subclassing.
But that introduced a compilation error because the method `init(wrappedValue: T)` and `var wrappedValue: T` must also be open.
The problem is that the initialisers cannot be open, and when changing the initializer to be open, the compiler shows the error `Only classes and overridable class members can be declared 'open'`
This needs more investigation, so I suggest to revert the open classes temporarily.

EDIT: Here is the a gist that shows the issue.
https://gist.github.com/4brunu/fe5f7ff855a1ff6fdd1528d96232b720
I'm not sure is it's possible for an open class to be a property wrapper.