### PR TITLE
Firing first event using thread

### DIFF
--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -13,7 +13,7 @@ public class ImmutableObservable<T> {
         didSet {
             let newValue = _value
             observers.values.forEach { observer, dispatchQueue in
-                notify(observer: observer, dispatchQueue, oldValue: oldValue)
+                notify(observer: observer, queue: dispatchQueue, value: newValue, oldValue: oldValue)
             }
         }
     }
@@ -36,7 +36,7 @@ public class ImmutableObservable<T> {
         let id = uniqueID.next()!
         
         observers[id] = (observer, queue)
-        notify(observer: observer, queue, oldValue: nil)
+        notify(observer: observer, queue: queue, value: self.value)
         
         let disposable = Disposable { [weak self] in
             self?.observers[id] = nil
@@ -54,10 +54,10 @@ public class ImmutableObservable<T> {
         return self
     }
     
-    fileprivate func notify(observer: @escaping Observer, _ queue: DispatchQueue? = nil, oldValue: T?) {
+    fileprivate func notify(observer: @escaping Observer, queue: DispatchQueue? = nil, value: T, oldValue: T? = nil) {
         if let queue = queue {
             queue.async {
-                observer(self.value, oldValue)
+                observer(value, oldValue)
             }
         } else {
             observer(value, oldValue)


### PR DESCRIPTION
This PR fixes the issue #32 where the first time we call the observer, right after subscribing, we where not using the given queue from the parameter.