### PR TITLE
Help with the migration process

### DIFF
--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -28,15 +28,7 @@ public class Observable<T> {
     }
     
     public var wrappedValue: T {
-        get {
-            return _value
-        }
-        @available(*, deprecated, message: "The `wrappedValue` in the `Observable` class is read only. If you want and change the `wrappedValue` please use a `MutableObservable` instead.")
-        set {
-            lock.lock()
-            defer { lock.unlock() }
-            _value = newValue
-        }
+        return _value
     }
     
     @available(*, deprecated, renamed: "wrappedValue")
@@ -44,6 +36,7 @@ public class Observable<T> {
         get {
             return _value
         }
+        @available(*, deprecated, message: "The `value` in the `Observable` class is read only. If you want and change the `value` please use a `MutableObservable` instead.")
         set {
             lock.lock()
             defer { lock.unlock() }
@@ -107,17 +100,4 @@ public class MutableObservable<T>: Observable<T> {
             _value = newValue
         }
     }
-    
-    @available(*, deprecated, renamed: "wrappedValue")
-    override public var value: T {
-        get {
-            return _value
-        }
-        set {
-            lock.lock()
-            defer { lock.unlock() }
-            _value = newValue
-        }
-    }
 }
-

--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -101,12 +101,11 @@ public class MutableObservable<T>: Observable<T> {
         }
     }
     
+    @available(*, deprecated, renamed: "wrappedValue")
     override public var value: T {
-        @available(*, deprecated, renamed: "wrappedValue")
         get {
             return _value
         }
-        @available(*, deprecated, renamed: "wrappedValue")
         set {
             lock.lock()
             defer { lock.unlock() }

--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -31,8 +31,8 @@ public class Observable<T> {
         return _value
     }
     
-    @available(*, deprecated, renamed: "wrappedValue")
     public var value: T {
+        @available(*, deprecated, renamed: "wrappedValue")
         get {
             return _value
         }
@@ -94,6 +94,19 @@ public class MutableObservable<T>: Observable<T> {
         get {
             return _value
         }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
+    }
+    
+    override public var value: T {
+        @available(*, deprecated, renamed: "wrappedValue")
+        get {
+            return _value
+        }
+        @available(*, deprecated, renamed: "wrappedValue")
         set {
             lock.lock()
             defer { lock.unlock() }

--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+@available(*, deprecated, renamed: "Observable", message: "`Observable` was renamed to `MutableObservable` and `ImmutableObservable` was renamed to `Observable`. An `Observable` can only read and observe changes on the `wrappedValue`. If you want to change the `wrappedValue` please use a `MutableObservable`instead.")
+public typealias ImmutableObservable = Observable
+
 public class Observable<T> {
     
     public typealias Observer = (T, T?) -> Void
@@ -25,7 +28,27 @@ public class Observable<T> {
     }
     
     public var wrappedValue: T {
-        return _value
+        get {
+            return _value
+        }
+        @available(*, deprecated, message: "The `wrappedValue` in the `Observable` class is read only. If you want and change the `wrappedValue` please use a `MutableObservable` instead.")
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
+    }
+    
+    @available(*, deprecated, renamed: "wrappedValue")
+    public var value: T {
+        get {
+            return _value
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
     }
       
     fileprivate var _onDispose: () -> Void
@@ -85,5 +108,16 @@ public class MutableObservable<T>: Observable<T> {
         }
     }
     
+    @available(*, deprecated, renamed: "wrappedValue")
+    override public var value: T {
+        get {
+            return _value
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
+    }
 }
 

--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -78,7 +78,7 @@ public class Observable<T> {
     }
     
     @available(*, deprecated, renamed: "asObservable")
-    public func asImmutable() -> Observable<T> {
+    public func asImmutable() -> ImmutableObservable<T> {
         return self
     }
     

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ dependencies: [
 ]
 ```
 
+## Migrations
+
+### 1.x.y to 2.0.0
+- `Observable` is now `MutableObservable`
+- `ImmutableObservable` is now `Observable`
+- `Observable.asImmutableObservable()` is now `Observable.asObservable()`
+- `Observable.value` is now `Observable.wrappedValue`
+
+
 ## Suggestions or feedback?
 
 Feel free to create a pull request, open an issue or find [me on Twitter](https://twitter.com/roberthein).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ position.observe(DispatchQueue.main) { p in
 ### Change the value
 
 ```swift
-position.value = p
+position.wrappedValue = p
 ```
 
 ## Memory management

--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ it, simply add the following line to your Podfile:
 pod 'Observable'
 ```
 
+### Swift Package Manager
+
+**Observable** is available through `Swift Package Manager`.
+[Swift Package Manager](https://swift.org/package-manager/) (SwiftPM) is a tool for automating the distribution of Swift code. 
+It is integrated into the swift compiler and from Xcode 11, SwiftPM got natively integrated with Xcode.
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/roberthein/Observable", from: "VERSION")
+]
+```
+
 ## Suggestions or feedback?
 
 Feel free to create a pull request, open an issue or find [me on Twitter](https://twitter.com/roberthein).


### PR DESCRIPTION
Hey,
Since the next release will include breaking changes I decided to include some deprecated warning to help with the migration process.
With this commit, the projects that use the old API, will still compile and work without any change.
They will also will see some warnings that guide them through the migration process.
~Maybe it would be a good idea to add some migration guide also, in the readme or the wiki.~
@roberthein what do you think of this PR?
Thanks

EDIT: I added a migration guide to the readme