### PR TITLE
Avoid deadlock by using NSRecursiveLock

### DIFF
--- a/Observable/Classes/Lock.swift
+++ b/Observable/Classes/Lock.swift
@@ -8,18 +8,4 @@ internal protocol Lock {
     func unlock()
 }
 
-internal final class Mutex: Lock {
-    private var mutex: pthread_mutex_t = {
-        var mutex = pthread_mutex_t()
-        pthread_mutex_init(&mutex, nil)
-        return mutex
-    }()
-
-    func lock() {
-        pthread_mutex_lock(&mutex)
-    }
-
-    func unlock() {
-        pthread_mutex_unlock(&mutex)
-    }
-}
+extension NSRecursiveLock: Lock {}

--- a/Observable/Classes/Observable.swift
+++ b/Observable/Classes/Observable.swift
@@ -10,7 +10,7 @@ public class Observable<T> {
     private var observers: [Int: (Observer, DispatchQueue?)] = [:]
     private var uniqueID = (0...).makeIterator()
     
-    fileprivate let lock: Lock = Mutex()
+    fileprivate let lock: Lock = NSRecursiveLock()
     
     fileprivate var _value: T {
         didSet {

--- a/Observable/Tests/Observable_Tests.swift
+++ b/Observable/Tests/Observable_Tests.swift
@@ -220,6 +220,25 @@ class Observable_Tests: XCTestCase {
         XCTAssert(true)
     }
     
+    func test_whenUpdatingValueFromObserver_shouldNotDeadLock() {
+        let exp = expectation(description: "")
+        exp.expectedFulfillmentCount = 4
+        let observable = MutableObservable(0)
+        var lastValueResult: Int?
+        
+        observable.observe { newValue, _ in
+            lastValueResult = newValue
+            exp.fulfill()
+            if newValue < 3 {
+                observable.wrappedValue = newValue + 1
+            }
+        }.add(to: &disposal)
+        
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(lastValueResult, 3)
+        XCTAssert(true)
+    }
+
     // MARK: - Using Singleton
     func test_whenUsingDispatchMain_shouldSucceed() {
         let exp = expectation(description: "")


### PR DESCRIPTION
Hey,
Currently Observable creates a deadlock when updating an Observable value from within its Observation as described https://github.com/roberthein/Observable/issues/19 and https://github.com/roberthein/Observable/pull/20.

This PR migrates the lock from `pthread_mutex_t` to `NSRecursiveLock` which avoids the deadlock problem.
This is also the solution used in RxSwift [1](https://github.com/ReactiveX/RxSwift/blob/6b2a406b928cc7970874dcaed0ab18e7265e41ef/RxSwift/Subjects/BehaviorSubject.swift#L31) [2](https://github.com/ReactiveX/RxSwift/blob/53cd723d40d05177e790c8c34c36cec7092a6106/Platform/RecursiveLock.swift#L33).



Regarding performance, it has a small overhead, which is expected, but I think it's not something noticeable, and it will avoid the dead lock situation.

Here are some performance tests on `pthread_mutex_t` and `NSRecursiveLock`.

https://github.com/nyisztor/LockTest#the-results
![](https://raw.githubusercontent.com/Carlos001/LockTest/master/lockPerformance.png)


https://gist.github.com/azinman/5410263c62157086943a#file-appdelegate-m-L30-L41
```
 Pthread mutex avg: 133 ns
 Pthread reentrant mutex avg: 194 ns
 Pthread reentrant mutex + exceptions avg: 191 ns
 Pthread 3x reentrant mutex + exceptions avg: 262 ns
 Pthread reentrant mutex contended on main avg: 742 ns
 Pthread reentrant mutex contended on high priority avg: 915 ns

 NSRecursiveLock avg: 188 ns
 NSRecursiveLock + exception handling avg: 179 ns
 NSRecursiveLock + exception handling 3x avg: 348 ns
 NSRecursiveLock under contention on main + exception handling avg: 758 ns
 NSRecursiveLock under contention on high priority + exception handling avg: 928 ns
```
This PR also has a unit tests that tests the deadlock situation.

@roberthein Please let me know if there is any additional changes to merge this 🙂 
Thanks