### PR TITLE
Make the Disposable initializer public

### DIFF
--- a/Observable/Classes/Disposable.swift
+++ b/Observable/Classes/Disposable.swift
@@ -14,7 +14,7 @@ public final class Disposable {
     
     public let dispose: () -> ()
     
-    init(_ dispose: @escaping () -> ()) {
+    public init(_ dispose: @escaping () -> ()) {
         self.dispose = dispose
     }
     


### PR DESCRIPTION
Our project has an extension to wrap some existing Observable-like APIs in the Realm framework so that they match the Observable API. In order to do this we need to create a `Disposable` object, but the initializer for `Disposable` isn't marked as public so it defaults to internal.

Can the initializer for `Disposable` be made public?